### PR TITLE
chore(release): prepare for v0.2.0

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,7 +1,0 @@
-[advisories]
-# TEMPORARY: Ignore timing vulnerability in curve25519-dalek v3.2.1
-# Reason: Maintaining compatibility with existing ecosystem dependencies
-# Timeline: Will upgrade to curve25519-dalek v4.1.3+ in v0.2.0
-# Tracking: This is a known limitation documented in README and CHANGELOG
-# ignore = ["RUSTSEC-2024-0344"]
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - No pending changes.
 
+## [v0.2.0] - 2026-01-03
+
+### Security
+- ✅ **FIXED**: Resolved RUSTSEC-2024-0344 timing vulnerability by upgrading curve25519-dalek from v3.2.1 to v4.1.3
+- ✅ All cryptographic operations now use constant-time implementations
+- ✅ Enhanced side-channel resistance in signature verification
+### Changed
+- **BREAKING**: Upgraded `curve25519-dalek` from v3 to v4.1.3
+  - Added `alloc` feature requirement for multiscalar multiplication
+  - Migrated from `optional_multiscalar_mul` to `multiscalar_mul` (removed in v4)
+- Updated `merlin` from v2 to v3
+- Updated `rand` from 0.7 to 0.8
+- Synced `rand_core` to 0.6 (resolves version conflicts)
+- Moved `hex` to regular dependencies (used in Debug formatting)
+
+### Fixed
+- Fixed batch verification to properly handle `Option<RistrettoPoint>` conversion
+- Resolved dependency version conflicts between merlin, rand, and curve25519-dalek
+- Fixed error handling in `SingleVerifier::append` for `None` point values
+
+### Technical Details
+- Batch verification now uses `multiscalar_mul` with proper `Option` handling
+- All multiscalar multiplication operations use constant-time implementations
+- Improved error messages for invalid point decompression
+
 ## [v0.1.1] - 2024-07-16
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zkschnorr"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Usman Shahid"]
 edition = "2021"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-zkschnorr = "0.1.0"
+zkschnorr = "0.2.0"
 ```
 
 ## Quick Start

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -53,20 +53,21 @@ impl BatchVerification for SingleVerifier {
             .chain(dynamic_scalars)
             .map(|s| *s.borrow())
             .collect::<Vec<_>>();
-        
+
         // Collect points and check for None values
         let points = match dynamic_points.into_iter().collect::<Option<Vec<_>>>() {
             Some(points) => points,
-            None => { self.result= Err(ZkSchnorrError::InvalidSignature);
+            None => {
+                self.result = Err(ZkSchnorrError::InvalidSignature);
                 return;
             }
         };
 
-                // multiscalar_mul now returns RistrettoPoint directly (not Option)
-        let result = RistrettoPoint::multiscalar_mul(scalars.into_iter(), points.into_iter());
-        
+        // multiscalar_mul now returns RistrettoPoint directly (not Option)
+        let result = RistrettoPoint::multiscalar_mul(scalars, points);
+
         self.result = if result.is_identity() {
-         Ok(())
+            Ok(())
         } else {
             Err(ZkSchnorrError::InvalidSignature)
         };
@@ -103,19 +104,17 @@ impl<R: RngCore + CryptoRng> BatchVerifier<R> {
             return Ok(());
         }
         // Convert Option<RistrettoPoint> to RistrettoPoint, returning error if any are None
-        let points: Vec<RistrettoPoint> = self.dyn_points
-        .into_iter()
-        .collect::<Option<Vec<_>>>()
-        .ok_or(ZkSchnorrError::InvalidBatch)?;
-        
+        let points: Vec<RistrettoPoint> = self
+            .dyn_points
+            .into_iter()
+            .collect::<Option<Vec<_>>>()
+            .ok_or(ZkSchnorrError::InvalidBatch)?;
+
         // multiscalar_mul now returns RistrettoPoint directly (not Option)
-        let result = RistrettoPoint::multiscalar_mul(
-            self.dyn_weights.into_iter(),
-            points.into_iter(),
-        );
+        let result = RistrettoPoint::multiscalar_mul(self.dyn_weights, points);
 
         if result.is_identity() {
-        Ok(())
+            Ok(())
         } else {
             Err(ZkSchnorrError::InvalidBatch)
         }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,13 +1,13 @@
+use super::Signature;
+use super::ZkSchnorrError;
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 use serde::{de::Deserializer, de::Visitor, ser::Serializer, Deserialize, Serialize};
-use super::Signature;
-use super::ZkSchnorrError;
 
 impl Signature {
     /// Decodes a signature from a 64-byte slice.
     pub fn from_bytes(sig: impl AsRefExt) -> Result<Self, ZkSchnorrError> {
-      let sig = sig.as_ref_ext();
+        let sig = sig.as_ref_ext();
         if sig.len() != 64 {
             return Err(ZkSchnorrError::InvalidSignature);
         }
@@ -15,28 +15,27 @@ impl Signature {
         let mut sbuf = [0u8; 32];
         rbuf[..].copy_from_slice(&sig[..32]);
         sbuf[..].copy_from_slice(&sig[32..]);
-        
+
         // Constant-time extraction
         let s_ct = Scalar::from_canonical_bytes(sbuf);
         // Extract scalar (using zero as dummy if invalid - constant time)
         let s = s_ct.unwrap_or(Scalar::ZERO);
-        
+
         // Check validity in constant time
         let is_valid = s_ct.is_some();
-        
+
         // Construct signature (works for both valid and invalid cases)
         let sig = Signature {
             R: CompressedRistretto(rbuf),
             s,
         };
-        
+
         // Return error only after constant-time work is done
         if bool::from(is_valid) {
             Ok(sig)
         } else {
             Err(ZkSchnorrError::InvalidSignature)
         }
-    
     }
 
     /// Encodes the signature as a 64-byte array.

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,7 +1,6 @@
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 use std::fmt;
-use hex;
 
 use super::batch::{BatchVerification, SingleVerifier};
 use super::errors::ZkSchnorrError;


### PR DESCRIPTION
- Update CHANGELOG.md with v0.2.0 release notes
- Document RUSTSEC-2024-0344 fix and dependency updates
- Ready for v0.2.0 tag creation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **v0.2.0 release** with security fix and breaking dependency upgrades.
> 
> - **Security**: Fixes RUSTSEC-2024-0344 by upgrading `curve25519-dalek` to v4.1.3; adopts constant-time ops throughout
> - **Breaking**: Migrates from `optional_multiscalar_mul` to `multiscalar_mul` (v4 API) and adds `alloc` feature requirement
> - **Batch verify**: Updates `batch.rs` to use new `multiscalar_mul` return type and strict `Option<RistrettoPoint>` handling; improves empty-batch handling
> - **Serialization**: `Signature::from_bytes` now performs constant-time scalar extraction and defers erroring until after CT work
> - **Deps**: Bumps `merlin` v2→v3, `rand` 0.7→0.8, `rand_core`→0.6; moves `hex` to regular deps
> - **Housekeeping**: Bumps crate to `0.2.0`, updates README install snippet, updates CHANGELOG; removes `.cargo/audit.toml` advisory ignore
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fda96f4e66448287fea31a96bfa95c3b66e09db8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->